### PR TITLE
Correct query to return UserAuthDetails

### DIFF
--- a/src/ServiceStack.Authentication.Neo4j/Neo4jAuthRepository.cs
+++ b/src/ServiceStack.Authentication.Neo4j/Neo4jAuthRepository.cs
@@ -423,7 +423,7 @@ namespace ServiceStack.Authentication.Neo4j
 
             var userAuthDetails = driver.ReadTxQuery(tx =>
             {
-                var result = tx.Run(Query.UserAuthByProviderAndUserId, parameters);
+                var result = tx.Run(Query.UserAuthDetailsByProviderAndUserId, parameters);
                 return result.Map<TUserAuthDetails>().SingleOrDefault() ?? new TUserAuthDetails
                 {
                     Provider = tokens.Provider,

--- a/src/ServiceStack.Server.Tests/AuthRepo/Neo4jAuthRepositoryTests.cs
+++ b/src/ServiceStack.Server.Tests/AuthRepo/Neo4jAuthRepositoryTests.cs
@@ -196,14 +196,15 @@ namespace ServiceStack.Server.Tests.AuthRepo
         {
             // Arrange
             var userAuth = Sut.CreateUserAuth(NewUserAuth, Password);
-            CreateUserAuthDetails(userAuth, "google");
+            var userAuthDetails = CreateUserAuthDetails(userAuth, "google");
 
             var authSession = new AuthUserSession();
 
             var tokens = new AuthTokens
             {
                 UserId = userAuth.Id.ToString(),
-                Provider = "google"
+                Provider = "google",
+                City = userAuthDetails.City
             };
             
             // Act
@@ -213,6 +214,7 @@ namespace ServiceStack.Server.Tests.AuthRepo
             result.Id.Should().BeGreaterThan(0);
             result.Id.Should().Be(result.UserAuthId);
             result.ModifiedDate.Should().BeAfter(userAuth.ModifiedDate);
+            result.City.Should().Be(userAuthDetails.City);
         }
 
         [Test]


### PR DESCRIPTION
Update query to return AuthDetails rather than UserAuth. Add test to check same instance has been returned and updated 